### PR TITLE
Chai assert return error plugin

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -65,7 +65,7 @@
     "camelcase": 1,
     "complexity": [1, 11],
     "consistent-this": 0,
-    "curly": 2,
+    "curly": [2, "multi-line"],
     "dot-notation": 2,
     "eqeqeq": 2,
     "handle-callback-err": 1,

--- a/lib/mink.js
+++ b/lib/mink.js
@@ -10,6 +10,10 @@
 var path  = require('path');
 var build = require('build-prototype');
 
+var chai    = require('chai');
+var chaiErr = require('./utils/chai-err.js');
+chai.use(chaiErr);
+
 var Mink = function() {
   this.initialized = false;
   this.parameters = {};

--- a/lib/step_definitions/ext/assert-dom.js
+++ b/lib/step_definitions/ext/assert-dom.js
@@ -7,17 +7,16 @@
  *     Arnaud Dezandee <dezandee.arnaud@gmail.com>
  */
 
-var _       = require('lodash'),
-    chai    = require('chai'),
-    assert  = chai.assert;
+var assert  = require('chai').assert;
+var _ = require('lodash');
 
 ///////////////////
 
 function browserHTML(assertFn) {
   return function(expectedText, callback) {
     this.driver.html(function (err, html) {
-      assertFn(html, expectedText);
-      callback(err);
+      if (err) return callback(err);
+      callback(assertFn(html, expectedText));
     });
   };
 }
@@ -31,11 +30,11 @@ function browserHTMLMatch(assertFn) {
 function elementHTML(assertFn) {
   return function(expectedText, selector, callback) {
     this.driver.html(selector, function (err, html) {
+      if (err) return callback(err);
       if (_.isArray(html)) {
         html = html.join('');
       }
-      assertFn(html, expectedText);
-      callback(err);
+      callback(assertFn(html, expectedText));
     });
   };
 }
@@ -43,8 +42,8 @@ function elementHTML(assertFn) {
 function elementsCount() {
   return function (expectedCount, selector, callback) {
     this.driver.elementsCount(selector, function (err, count) {
-      assert.strictEqual(count, parseInt(expectedCount));
-      callback(err);
+      if (err) return callback(err);
+      callback(assert.returnError.strictEqual(count, parseInt(expectedCount)));
     });
   };
 }
@@ -52,8 +51,8 @@ function elementsCount() {
 function elementState(method, state) {
   return function(selector, callback) {
     this.driver[method](selector, function (err, res) {
-      assert.strictEqual(res, state);
-      callback(err);
+      if (err) return callback(err);
+      callback(assert.returnError.strictEqual(res, state));
     });
   };
 }
@@ -63,12 +62,12 @@ function elementState(method, state) {
 module.exports = {
   _elementState:          elementState,
   _elementHTML:           elementHTML,
-  containsText:           browserHTML(assert.include),
-  notContainsText:        browserHTML(assert.notInclude),
-  matchesText:            browserHTMLMatch(assert.match),
-  notMatchesText:         browserHTMLMatch(assert.notMatch),
-  elementContainsText:    elementHTML(assert.include),
-  elementNotContainsText: elementHTML(assert.notInclude),
+  containsText:           browserHTML(assert.returnError.include),
+  notContainsText:        browserHTML(assert.returnError.notInclude),
+  matchesText:            browserHTMLMatch(assert.returnError.match),
+  notMatchesText:         browserHTMLMatch(assert.returnError.notMatch),
+  elementContainsText:    elementHTML(assert.returnError.include),
+  elementNotContainsText: elementHTML(assert.returnError.notInclude),
   elementsCount:          elementsCount(),
   elementVisible:         elementState('isVisible', true),
   elementNotVisible:      elementState('isVisible', false),

--- a/lib/step_definitions/ext/assert-form.js
+++ b/lib/step_definitions/ext/assert-form.js
@@ -9,9 +9,8 @@
 
 var util = require('util');
 
-var async   = require('async'),
-    chai    = require('chai'),
-    assert  = chai.assert;
+var async   = require('async');
+var assert  = require('chai').assert;
 
 var assertDOM = require('./assert-dom.js');
 
@@ -20,8 +19,8 @@ var assertDOM = require('./assert-dom.js');
 function fieldValue(assertionFn) {
   return function(fieldSelector, expectedValue, callback) {
     this.driver.getValue(fieldSelector, function (err, res) {
-      assertionFn(res, expectedValue);
-      callback(err);
+      if (err) return callback(err);
+      callback(assertionFn(res, expectedValue));
     });
   };
 }
@@ -45,9 +44,9 @@ function selectHTML(assertionFn) {
 ///////////////////
 
 module.exports = {
-  selectContains:     selectHTML(assert.include),
-  fieldContains:      fieldValue(assert.include),
-  fieldNotContains:   fieldValue(assert.notInclude),
+  selectContains:     selectHTML(assert.returnError.include),
+  fieldContains:      fieldValue(assert.returnError.include),
+  fieldNotContains:   fieldValue(assert.returnError.notInclude),
   fieldEnabled:       assertDOM._elementState('isEnabled', true),
   fieldDisabled:      assertDOM._elementState('isEnabled', false),
   checkboxChecked:    assertDOM._elementState('isChecked', true),

--- a/lib/step_definitions/ext/assert-url.js
+++ b/lib/step_definitions/ext/assert-url.js
@@ -7,36 +7,35 @@
  *     Arnaud Dezandee <dezandee.arnaud@gmail.com>
  */
 
-var chai    = require('chai'),
-    assert  = chai.assert;
+var assert = require('chai').assert;
 
 ///////////////////
 
 function browserUrl(property, assertionFn) {
   return function (input, callback) {
     this.driver.url(function (err, oUrl) {
-      assertionFn(oUrl[property], input);
-      callback(err);
+      if (err) return callback(err);
+      callback(assertionFn(oUrl[property], input));
     });
   };
 }
 
 function browserUrlMatch(property) {
   return function(pattern, callback) {
-    browserUrl(property, assert.match).bind(this)(new RegExp(pattern), callback);
+    browserUrl(property, assert.returnError.match).bind(this)(new RegExp(pattern), callback);
   };
 }
 
 function browserRoot() {
   return function (callback) {
-    browserUrl('pathname', assert.equal).bind(this)('/', callback);
+    browserUrl('pathname', assert.returnError.equal).bind(this)('/', callback);
   };
 }
 
 ///////////////////
 
 module.exports = {
-  equal:       browserUrl('pathname', assert.equal),
+  equal:       browserUrl('pathname', assert.returnError.equal),
   match:       browserUrlMatch('pathname'),
   queryMatch:  browserUrlMatch('search'),
   root:        browserRoot()

--- a/lib/utils/chai-err.js
+++ b/lib/utils/chai-err.js
@@ -1,0 +1,19 @@
+module.exports = function(chai) {
+  var assert = chai.assert;
+
+  var originalAssertMethods = Object.getOwnPropertyNames(assert).filter(function (propName) {
+    return typeof assert[propName] === 'function';
+  });
+
+  assert.returnError = {};
+  originalAssertMethods.forEach(function (assertMethodName) {
+    assert.returnError[assertMethodName] = function () {
+      var args = Array.prototype.slice.call(arguments, 0);
+      try {
+        return assert[assertMethodName].apply(assert, args);
+      } catch (error) {
+        return error;
+      }
+    };
+  });
+};

--- a/test/features/assert_content.feature
+++ b/test/features/assert_content.feature
@@ -23,3 +23,7 @@ Feature: I can use cucumber.mink to check the content of my website
     | path         | count |
     | /generate/7  | 7     |
     | /generate/30 | 30    |
+
+  # Internals specs
+  Scenario:
+    * I test step assert dom html

--- a/test/features/step.feature
+++ b/test/features/step.feature
@@ -1,5 +1,5 @@
 Feature: Steps tests
 
   Scenario:
-    * I test step root
-    * I test browse path
+    * I test step navigation base url
+    * I test step navigation root

--- a/test/features/step_definitions/asserts.js
+++ b/test/features/step_definitions/asserts.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  this.Given(/^I test step assert dom html/, require('../../spec/step/assert-dom.js'));
+};

--- a/test/features/step_definitions/steps.js
+++ b/test/features/step_definitions/steps.js
@@ -1,4 +1,4 @@
 module.exports = function() {
-  this.Given(/^I test step root/,   require('../../spec/steps/root.js'));
-  this.Given(/^I test browse path/, require('../../spec/steps/root.js'));
+  this.Given(/^I test step navigation base url/, require('../../spec/step/navigation/base_url.js'));
+  this.Given(/^I test step navigation root/,   require('../../spec/step/navigation/root.js'));
 };

--- a/test/spec/methods/findStep.js
+++ b/test/spec/methods/findStep.js
@@ -1,4 +1,4 @@
-var Mink  = require('../../../lib/mink');
+var Mink = require('../../../lib/mink');
 
 var assert = require('chai').assert;
 

--- a/test/spec/methods/manyStep.js
+++ b/test/spec/methods/manyStep.js
@@ -1,4 +1,4 @@
-var Mink  = require('../../../lib/mink');
+var Mink = require('../../../lib/mink');
 
 module.exports = function manyStep(callback) {
   Mink.manyStep([

--- a/test/spec/methods/metaStep.js
+++ b/test/spec/methods/metaStep.js
@@ -1,7 +1,7 @@
-var Mink  = require('../../../lib/mink');
+var Mink = require('../../../lib/mink');
 
-var async = require('async'),
-    assert = require('chai').assert;
+var async  = require('async');
+var assert = require('chai').assert;
 
 module.exports = function metaStep(callback) {
   var stepArray1 = [{

--- a/test/spec/step/assert-dom.js
+++ b/test/spec/step/assert-dom.js
@@ -1,0 +1,13 @@
+var Mink   = require('../../../lib/mink.js');
+
+var chai = require('chai');
+var assert = chai.assert;
+var AssertionError = chai.AssertionError;
+
+module.exports = function root(callback) {
+  Mink.runStep('Then I should see "Hello world"', function(err) {
+    assert.isNotNull(err);
+    assert(err instanceof AssertionError);
+    callback();
+  });
+};

--- a/test/spec/step/navigation/base_url.js
+++ b/test/spec/step/navigation/base_url.js
@@ -1,5 +1,5 @@
-var Mink   = require('../../../lib/mink.js');
-var Errors = require('../../../lib/utils/errors.js');
+var Mink   = require('../../../../lib/mink.js');
+var Errors = require('../../../../lib/utils/errors.js');
 
 var assert = require('chai').assert;
 

--- a/test/spec/step/navigation/root.js
+++ b/test/spec/step/navigation/root.js
@@ -1,5 +1,5 @@
-var Mink   = require('../../../lib/mink.js');
-var Errors = require('../../../lib/utils/errors.js');
+var Mink   = require('../../../../lib/mink.js');
+var Errors = require('../../../../lib/utils/errors.js');
 
 var assert = require('chai').assert;
 


### PR DESCRIPTION
Chai AssertionErrors are now returned through the callback pipe instead of being thrown wildly
Should fix #24 