### PR TITLE
Addition of default timeout option and corresponding CLI flag

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -24,6 +24,7 @@ const cli = meow(`
     --inject       Mink auto-inject in context           [Boolean] [default: true]
     --browser      Desired browser name              [String] [default: "firefox"]
     --port         Selenium server port                            [default: 4444]
+    --timeout      Cucumber function timeout in ms                 [default: 5000]
     -h, --help     Display help message                                  [Boolean]
     -v, --version  Display package version                               [Boolean]
 `, {
@@ -31,6 +32,7 @@ const cli = meow(`
     inject: true,
     browser: 'chrome',
     port: 4444,
+    timeout: 5000,
   },
   boolean: ['inject'],
   alias: {
@@ -45,6 +47,7 @@ const injectArgs = (flags) => {
   const params = Mink.DEFAULT_PARAMS;
   params.driver.desiredCapabilities.browserName = flags.browser;
   params.driver.port = flags.port;
+  params.timeout = flags.timeout;
 
   const inject = require('./cli/support/mink_inject.js');
 

--- a/src/mink.js
+++ b/src/mink.js
@@ -42,6 +42,7 @@ const DEFAULT_PARAMS = {
     logLevel: 'silent',
     port: 4444,
   },
+  timeout: 5000,
 };
 
 function noop() {
@@ -176,6 +177,8 @@ class Mink {
     cucumber.registerHandler('AfterFeatures', (/* event */) =>
       driver.end(),
     );
+
+    cucumber.setDefaultTimeout(this.parameters.timeout);
 
     if (driver.parameters.screenshotPath) {
       cucumber.After((event) => {

--- a/test/mocha/mink.test.js
+++ b/test/mocha/mink.test.js
@@ -16,6 +16,7 @@ import Step from '../../src/step.js';
 const mockCucumber = () => ({
   defineStep: jest.fn(),
   registerHandler: jest.fn(),
+  setDefaultTimeout: jest.fn(),
 });
 
 describe('Mink API', () => {
@@ -43,6 +44,7 @@ describe('Mink API', () => {
       expect(cucumber.registerHandler.mock.calls.length).to.equal(2);
       expect(cucumber.registerHandler.mock.calls[0][0]).to.equal('BeforeFeatures');
       expect(cucumber.registerHandler.mock.calls[1][0]).to.equal('AfterFeatures');
+      expect(cucumber.setDefaultTimeout.mock.calls[0][0]).to.equal(5000);
     });
   });
 


### PR DESCRIPTION
This PR will add in the ability to specify a `--timeout` flag in milliseconds on execution of the CLI, and also defines the default timeout to be 5000ms (the same as the cucumber-js default) unless specified.

Forthcoming is a PR to update the gh-pages branch.