### PR TITLE
Screenshot-Related Flags, Params, and Enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # CHANGELOG
 
+## 1.6.0 (2017-04-05)
+
+#### Features
+
+* **mink:** change default browser to chrome ([3d0b8514](https://github.com/Adezandee/cucumber-mink/commit/3d0b8514))
+* **package:** update dependencies ([0fd8b1e2](https://github.com/Adezandee/cucumber-mink/commit/0fd8b1e2))
+
+
+## 1.5.0 (2016-09-04)
+
+#### Features
+- **package:** update cucumber version 1.2.2 ([a27b65cf](https://github.com/Adezandee/cucumber-mink/commit/a27b65cf))
+
+
+### 1.4.1 (2016-06-28)
+
+#### Bug Fixes
+- **step:** isEnabled step may apply to an element ([9b8b8a95](https://github.com/Adezandee/cucumber-mink/commit/9b8b8a95))
+
+
+## 1.4.0 (2016-06-23)
+
+#### Features
+- **step:** add new step to assert element text only ([b59c7dfe](https://github.com/Adezandee/cucumber-mink/commit/b59c7dfe))
+
+
+## 1.3.0 (2016-06-21)
+
+#### Features
+- **driver:** add protractor driver for angular apps ([f1c808b4](https://github.com/Adezandee/cucumber-mink/commit/f1c808b4))
+
 ### 1.2.3 (2016-05-31)
 
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "lodash.defaultsdeep": "4.6.0",
     "meow": "3.7.0",
     "util-arity": "1.1.0",
+    "wdio-screenshot": "^0.5.2",
     "webdriverio": "4.6.2"
   },
   "devDependencies": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -21,16 +21,18 @@ const cli = meow(`
   Usage: cucumber-mink [options] -- [CUCUMBER ARGS]
 
   Options:
-    --inject       Mink auto-inject in context           [Boolean] [default: true]
-    --browser      Desired browser name              [String] [default: "firefox"]
-    --port         Selenium server port                            [default: 4444]
-    -h, --help     Display help message                                  [Boolean]
-    -v, --version  Display package version                               [Boolean]
+    --inject            Mink auto-inject in context                     [Boolean] [default: true]
+    --browser           Desired browser name                        [String] [default: "firefox"]
+    --port              Selenium server port                                      [default: 4444]
+    --screenshot-path   Path to which to save screenshots on failure    [String] [default: empty]
+    -h, --help          Display help message                                            [Boolean]
+    -v, --version       Display package version                                         [Boolean]
 `, {
   default: {
     inject: true,
     browser: 'chrome',
     port: 4444,
+    'screenshot-path': undefined, // showing default for clarity
   },
   boolean: ['inject'],
   alias: {
@@ -45,6 +47,7 @@ const injectArgs = (flags) => {
   const params = Mink.DEFAULT_PARAMS;
   params.driver.desiredCapabilities.browserName = flags.browser;
   params.driver.port = flags.port;
+  params.driver.screenshotPath = flags['screenshot-path'];
 
   const inject = require('./cli/support/mink_inject.js');
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -26,6 +26,9 @@ const cli = meow(`
     --port              Selenium server port                                      [default: 4444]
     --timeout           Cucumber function timeout in ms                           [default: 5000]
     --screenshot-path   Path to which to save screenshots on failure    [String] [default: empty]
+    --wdio-screenshot   Use wdio-screenshot if defined. One of:         [String] [default: empty]
+                          * 'viewport' - save screenshot of viewport only
+                          * 'document' - save screenshot of entire document
     -h, --help          Display help message                                            [Boolean]
     -v, --version       Display package version                                         [Boolean]
 `, {
@@ -35,6 +38,7 @@ const cli = meow(`
     port: 4444,
     timeout: 5000,
     'screenshot-path': undefined, // showing default for clarity
+    'wdio-screenshot': undefined, // showing default for clarity
   },
   boolean: ['inject'],
   alias: {
@@ -43,14 +47,33 @@ const cli = meow(`
   },
 });
 
+const configureWDIOScreenshot = (params, method) => {
+  const newParams = params;
+  switch (method) {
+    case undefined: {
+      break;
+    }
+    case 'viewport' || 'document': {
+      newParams.driver.plugins = { 'wdio-screenshot': {} };
+      newParams.screenshotMethod = `save${method.charAt(0).toUpperCase()}${method.slice(1)}Screenshot`;
+      break;
+    }
+    default: {
+      throw new Error(`'${method}' is not a valid value. Use one of: 'viewport', 'document'`);
+    }
+  }
+  return newParams;
+};
+
 const injectArgs = (flags) => {
   if (!flags.inject) return [];
 
-  const params = Mink.DEFAULT_PARAMS;
+  let params = Mink.DEFAULT_PARAMS;
   params.driver.desiredCapabilities.browserName = flags.browser;
   params.driver.port = flags.port;
   params.timeout = flags.timeout;
   params.driver.screenshotPath = flags['screenshot-path'];
+  params = configureWDIOScreenshot(params, flags['wdio-screenshot']);
 
   const inject = require('./cli/support/mink_inject.js');
 

--- a/src/mink.js
+++ b/src/mink.js
@@ -43,6 +43,7 @@ const DEFAULT_PARAMS = {
     port: 4444,
   },
   timeout: 5000,
+  screenshotMethod: 'saveScreenshot',
 };
 
 function noop() {
@@ -186,7 +187,7 @@ class Mink {
 
         const fileName = [event.getName() || 'Error', ':', event.getLine(), '.png'].join('');
         const filePath = path.join(driver.parameters.screenshotPath, fileName);
-        return driver.saveScreenshot(filePath);
+        return driver[this.parameters.screenshotMethod](filePath);
       });
     }
   }

--- a/test/mocha/mink.test.js
+++ b/test/mocha/mink.test.js
@@ -17,6 +17,7 @@ const mockCucumber = () => ({
   defineStep: jest.fn(),
   registerHandler: jest.fn(),
   setDefaultTimeout: jest.fn(),
+  After: jest.fn(),
 });
 
 describe('Mink API', () => {
@@ -45,6 +46,27 @@ describe('Mink API', () => {
       expect(cucumber.registerHandler.mock.calls[0][0]).to.equal('BeforeFeatures');
       expect(cucumber.registerHandler.mock.calls[1][0]).to.equal('AfterFeatures');
       expect(cucumber.setDefaultTimeout.mock.calls[0][0]).to.equal(5000);
+    });
+
+    it('init with driver.screenshotPath and screenshotMethod', () => {
+      const params = {
+        driver: {
+          screenshotPath: '/foo/bar',
+        },
+        screenshotMethod: 'saveDocumentScreenshot',
+      };
+      const cucumber = mockCucumber();
+      Mink.init(cucumber, params);
+      Mink.driver.saveDocumentScreenshot = jest.fn();
+      const mockEvent = {
+        isFailed: () => true,
+        getName: () => 'mock-test',
+        getLine: () => '69',
+      };
+      expect(cucumber.After.mock.calls).to.have.lengthOf(1);
+      cucumber.After.mock.calls[0][0](mockEvent);
+      expect(Mink.driver.saveDocumentScreenshot.mock.calls).have.lengthOf(1);
+      expect(Mink.driver.saveDocumentScreenshot.mock.calls[0][0]).to.equal('/foo/bar/mock-test:69.png');
     });
   });
 


### PR DESCRIPTION
This adds two new CLI flags:

- **`screenshotPath`** for defining the default screenshot path (which also already enables screenshots on failure and error)
- **`wdio-screenshot`** for both enabling the use of the [wdio-screenshot plugin](https://www.npmjs.com/package/wdio-screenshot) for WebdriverIO and setting which of the screenshot methods to use (`viewport` and `document`)

Along with the use of wdio-screenshot comes the ability to take entire document screenshots instead of just the viewport, which is extremely helpful in the case of off-viewport elements being tested (e.g. for presence).

The parameters are well-tested, and as an added benefit, the `After` hook also gets tested as a bonus.