### PR TITLE
Adjusted elements-with-text to allow padding when matching text

### DIFF
--- a/src/mink.js
+++ b/src/mink.js
@@ -80,7 +80,7 @@ Mink.prototype.elementsWithText = function (selector, text) {
   return self.page.$$(selector).then(items => Promise.filter(items, (handle) => {
     /* istanbul ignore next */
     return self.page.evaluate(obj => obj.innerText, handle)
-      .then(res => res.toUpperCase() === text.toUpperCase());
+      .then(res => res.toUpperCase().trim() === text.toUpperCase());
   }));
 };
 


### PR DESCRIPTION
- Adjusted elements-with-text to allow padding when matching text

Sorry, not sure where in the test/site structure would be a good place to put a test for this one.

```html
<a>No padding link</a> works fine
<a>
    Link with padding in the formatting
</a> can't be found without matching the padding in the step.
```

> Given I follow "Link with padding in the formatting"

elementsWithValue has a similar padding-sensitive behavior, but not sure how often stray padding would show up in input.value or similar.